### PR TITLE
Adds PHP 7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-ARG ALPINE_VERSION
+ARG ALPINE_VERSION=3.11
 FROM alpine:${ALPINE_VERSION}
 LABEL maintainer="Thomas Spicer (thomas@openbridge.com)"
+ARG ALPINE_VERSION
 
 ENV VAR_PREFIX=/var/run
 ENV LOG_PREFIX=/var/log/php-fpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.11
+ARG ALPINE_VERSION
+FROM alpine:${ALPINE_VERSION}
 LABEL maintainer="Thomas Spicer (thomas@openbridge.com)"
 
 ENV VAR_PREFIX=/var/run
@@ -14,7 +15,7 @@ RUN set -x \
       linux-headers \
       curl \
       unzip \
-  && echo '@community http://dl-cdn.alpinelinux.org/alpine/v3.11/community' >> /etc/apk/repositories \
+  && echo "@community http://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/community" >> /etc/apk/repositories \
   && apk add --no-cache --update \
       php7@community \
       php7-dev@community \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This is a Docker image creates a high performance, optimized container for PHP-F
 # Versioning
 | Docker Tag | Git Hub Release | PHP Version | Alpine Version |
 |-----|-------|-----|--------|
-| latest | develop | 7.3.x | 3.11 |
+| 7.3 | 7.3 | 7.3.x | 3.11 |
+| 7.4 | develop | 7.4.x | 3.13 |
+| latest | develop | 7.4.x | 3.13 |
 
 # Build
 ```

--- a/shippable.yml
+++ b/shippable.yml
@@ -7,9 +7,12 @@ env:
   - PHP_VERSION=7.4 TAG=latest
 
 pre_ci:
-  - export ALPINE_VERSION="3.13"
-  - if [ "$PHP_VERSION" == "7.3" ]; then export ALPINE_VERSION="3.11"; fi
-  - docker build --build-arg ALPINE_VERSION=$ALPINE_VERSION -t $SHIPPABLE_CONTAINER_NAME:$TAG
+  - |
+    if [ "$PHP_VERSION" == "7.4" ]; then
+        docker build --build-arg ALPINE_VERSION=3.13 -t $SHIPPABLE_CONTAINER_NAME:$TAG
+    else
+        docker build -t $SHIPPABLE_CONTAINER_NAME:$TAG
+    fi
 
 build:
   post_ci:

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,9 +1,17 @@
 # language setting
 language: none
 
+env:
+  - PHP_VERSION=7.3 TAG=7.3
+  - PHP_VERSION=7.4 TAG=7.4
+  - PHP_VERSION=7.4 TAG=latest
+
 pre_ci:
-      - docker build -t $SHIPPABLE_CONTAINER_NAME:latest
+  - export ALPINE_VERSION="3.13"
+  - if [ "$PHP_VERSION" == "7.3" ]; then export ALPINE_VERSION="3.11"; fi
+  - docker build --build-arg ALPINE_VERSION=$ALPINE_VERSION -t $SHIPPABLE_CONTAINER_NAME:$TAG
+
 build:
-    post_ci:
-      - sudo pip install -U docker-compose awscli
-      - docker commit $SHIPPABLE_CONTAINER_NAME
+  post_ci:
+    - sudo pip install -U docker-compose awscli
+    - docker commit $SHIPPABLE_CONTAINER_NAME


### PR DESCRIPTION
Alpine 3.13 has just been released, and it natively supports PHP 7.4 and PHP 8. This PR allows switching between Alpine versions for installing specific PHP versions.

I don't know if you use shippable.yml to push builds to Dockerhub. If so, this PR shows a sample of how to adapt the build process to PR changes.